### PR TITLE
Avoid loading default skin twice.

### DIFF
--- a/Extensions/CCSpine/CCSpineSkeleton.m
+++ b/Extensions/CCSpine/CCSpineSkeleton.m
@@ -414,7 +414,8 @@ const NSInteger CCSpineSkeletonBoneZInterval = 10;
     // clear old skin
     [self clearSkin];
     // load default section
-    [self assignSubSkin:_defaultSkin];
+    if (_defaultSkin != skin)
+        [self assignSubSkin:_defaultSkin];
     // load main skin
     [self assignSubSkin:skin];
 }


### PR DESCRIPTION
You must set a skin but if the only skin is the default skin, calling

    [skel assignSkinByName: @"default"]

causes lots of

    Warning ! Sprite %@ already added to sprite %@

messages for every sprite in the default skin.