### PR TITLE
Return the correct texture frame in animations with only one key

### DIFF
--- a/Extensions/CCSpine/CCSpineAnimation.m
+++ b/Extensions/CCSpine/CCSpineAnimation.m
@@ -179,7 +179,7 @@ typedef void (*animationCallback)(id, SEL, id);
     if (textureList.count == 1)
     {
         current = [textureList objectAtIndex:0];
-        if (time < current.time) return(current);
+        if (time >= current.time) return(current);
         return(nil);
     }
     //


### PR DESCRIPTION
Bones with only one attachment key at the beginning would always return nil since current.time was 0 and time is never less than 0. From what I can deduce this should be the correct logic as it returns the frame as long as the time is greater than or equal to the frame time. It solved the problem I was having when using a different image for a bone on a specific animation.

There is also a workaround until this has been merged. Simply add a second key with the same attachment shortly after the first and this code won't be reached.