### PR TITLE
Modify CCCropNode to use node parent when getting world position of node

### DIFF
--- a/Extensions/CCCropNode/CCCropNode.m
+++ b/Extensions/CCCropNode/CCCropNode.m
@@ -87,7 +87,7 @@
         float scale = [CCDirector sharedDirector].contentScaleFactor;
         
         size = node.contentSize;
-        pos = [node convertToWorldSpace:node.position];
+        pos = [node.parent convertToWorldSpace:node.position];
         
         [renderer enqueueBlock:^{
             glScissor(pos.x * scale, pos.y * scale, size.width * scale, size.height * scale);


### PR DESCRIPTION
We should be calling convertToWorldSpace on the parent of node in order to properly get node's world position.
