### PR TITLE
Allow multiple skins

### DIFF
--- a/Extensions/CCSpine/CCSpineSkeleton.h
+++ b/Extensions/CCSpine/CCSpineSkeleton.h
@@ -61,6 +61,7 @@
 // assigns a complete skin to skeleton
 - (void)assignSkin:(CCSpineSkin *)skin;
 - (void)assignSkinByName:(NSString *)skinName;
+- (void)assignSubSkin:(CCSpineSkin *)skin;
 - (void)replaceTexture:(NSString *)oldTextureName newTextureName:(NSString *)newTextureName;
 - (void)clearSkin;
 


### PR DESCRIPTION
By making assignSubSkin public it's possible to have multiple skins at once by fist calling assignSkin/assignSkinByName and then adding more skins with assignSubSkin. This is allowed by Spine although it isn't supported in the editor yet (https://trello.com/c/7WRv4DuN/71-allow-multiple-skins-to-be-activated-at-once).

I have been using this for a while and haven't had any problems apart from warnings about adding sprites that have already been added but addTexture just returns after the warning so it has no ill effects.