### PR TITLE
Fixing the crop area

### DIFF
--- a/Extensions/CCCropNode/CCCropNode.m
+++ b/Extensions/CCCropNode/CCCropNode.m
@@ -86,9 +86,9 @@
         CGSize size;
         float scale = [CCDirector sharedDirector].contentScaleFactor;
         
-        size = node.contentSize;
-        pos = [node convertToWorldSpace:node.position];
-        
+        size = node.contentSizeInPoints;
+        pos = [node convertToWorldSpace:CGPointZero];
+
         [renderer enqueueBlock:^{
             glScissor(pos.x * scale, pos.y * scale, size.width * scale, size.height * scale);
             glEnable(GL_SCISSOR_TEST);


### PR DESCRIPTION
If the node used for defining the crop area is not at 0,0 then the code would scissor the wrong area. 
If the crop node had a content size defined as other than CCSizeTypePoints it would get the wrong size.