### PR TITLE
Fix problems when using CCCropNode with another CCCropNode

### DIFF
--- a/Extensions/CCCropNode/CCCropNode.m
+++ b/Extensions/CCCropNode/CCCropNode.m
@@ -79,6 +79,11 @@
     CCNode *node = _cropNode;
     if ((node == nil) && (self.children.count)) node = [self.children objectAtIndex:0];
     
+    // store previous scissors info
+    GLint rect[4];
+    BOOL scissorsExist = glIsEnabled(GL_SCISSOR_TEST);
+    glGetIntegerv(GL_SCISSOR_BOX, rect);
+
     if (node && ((_mode == CCCropModeGraphics) || (_mode == CCCropModeGraphicsAndTouches)))
     {
         // enable scissors
@@ -98,7 +103,12 @@
     // render children
     [super visit:renderer parentTransform:parentTransform];
 
-    if (node && ((_mode == CCCropModeGraphics) || (_mode == CCCropModeGraphicsAndTouches)))
+    // restore previous scissors info
+    if ( scissorsExist == YES )
+    {
+        glScissor(rect[0], rect[1], rect[2], rect[3]);
+    }
+    else if (node && ((_mode == CCCropModeGraphics) || (_mode == CCCropModeGraphicsAndTouches)))
     {
         // disable scissors
         [renderer enqueueBlock:^{


### PR DESCRIPTION
When used CCCropNode elsewhere already, modifying rect and disabling GL_SCISSOR_TEST makes a problem.

So it needs to store and to restore GL_SCISSOR_TEST informations.