### PR TITLE
Fixing an issue in Tag handling

### DIFF
--- a/Extensions/CCNodeTag/CCNodeTag.m
+++ b/Extensions/CCNodeTag/CCNodeTag.m
@@ -38,7 +38,7 @@ static void *nodeTagKey = &nodeTagKey;
 
 - (void)addChild:(CCNode *)node z:(NSInteger)z tag:(NSInteger)tag
 {
-    self.tag = tag;
+    node.tag = tag;
     [self addChild:node z:z];
 }
 


### PR DESCRIPTION
tag of the child about to be added needs to be set, not the tag of the parent. The existing code causes child to get added to the parent, but calls to getChildByTag with same tag to parent to return nil (instead of the originally added child). This change fixes the issue. 